### PR TITLE
update sbt and Scala versions; remove old versions from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Dwolla Dev <dev+sbt@dwolla.com>"
 LABEL org.label-schema.vcs-url="https://github.com/Dwolla/docker-sbt-version-cache"
 
 USER root
-ENV SBT_VERSION=1.1.5 \
+ENV SBT_VERSION=1.2.1 \
     SBT_HOME=/usr/local/sbt
 ENV PATH=${SBT_HOME}/bin:${PATH}
 
@@ -14,7 +14,7 @@ RUN curl -sL /tmp/sbt-${SBT_VERSION}.tgz "https://github.com/sbt/sbt/releases/do
     gunzip | tar -x -C /usr/local
 
 RUN cd /fake-project && \
-    for version in 0.13.16 0.13.17 1.0.4 1.1.0 1.1.1 1.1.2 1.1.4 1.1.5; do \
+    for version in 1.2.1; do \
         echo sbt.version=${version} > project/build.properties && \
         sbt -Dsbt.log.noformat=true clean +compile; \
     done

--- a/fake-project/build.sbt
+++ b/fake-project/build.sbt
@@ -2,18 +2,11 @@ lazy val buildSettings = Seq(
   name := "fake-project",
   organization := "com.dwolla",
   version := "0.0.1",
-  scalaVersion := "2.12.5",
+  scalaVersion := "2.12.6",
   crossScalaVersions := Seq(
-    "2.11.8",
-    "2.11.11",
     "2.11.12",
-    "2.12.1",
-    "2.12.2",
-    "2.12.3",
-    "2.12.4",
-    "2.12.5",
     "2.12.6",
-    "2.13.0-M4"
+    "2.13.0-M5"
   )
 )
 


### PR DESCRIPTION
My thinking here is that there are now no blockers from upgrading sbt to 1.2.1, and Scala versions to 2.12.6 / 2.11.12, so we're better off shrinking the Docker image size by removing older versions and expecting our projects to upgrade as far as they can.